### PR TITLE
Add missing license headers [automated]\n\nModified files:\n- sage-sd…

### DIFF
--- a/sage-sdk/docs/SDK-Overview.md
+++ b/sage-sdk/docs/SDK-Overview.md
@@ -1,0 +1,9 @@
+<!--
+─────────────────────────────────────────────────────────────────────────────
+SAGE OS — Copyright (c) 2025 Ashish Vasant Yesale (ashishyesale007@gmail.com)
+SPDX-License-Identifier: BSD-3-Clause OR Proprietary
+SAGE OS is dual-licensed under the BSD 3-Clause License and a Commercial License.
+
+This file is part of the SAGE OS Project.
+─────────────────────────────────────────────────────────────────────────────
+-->


### PR DESCRIPTION
…k/docs/SDK-Overview.md\n

## Summary by Sourcery

Documentation:
- Insert dual-license BSD-3-Clause and Commercial SPDX header into SDK-Overview.md