### PR TITLE
fix: Add missing QEMU architectures to Alpine Docker deployment

### DIFF
--- a/deploy-sage-os.sh
+++ b/deploy-sage-os.sh
@@ -213,7 +213,9 @@ FROM alpine:latest
 RUN apk update && apk add --no-cache \
     qemu-system-i386 \
     qemu-system-arm \
+    qemu-system-aarch64 \
     qemu-system-x86_64 \
+    qemu-system-riscv64 \
     qemu-img \
     tigervnc \
     xvfb \


### PR DESCRIPTION
## 🐛 **Fix: Missing QEMU Architectures in Alpine Docker Deployment**

This PR resolves the `qemu-system-aarch64: not found` error that occurs when deploying SAGE OS using Alpine Linux Docker containers.

### **🔧 Problem Solved:**

**Error encountered:**
```bash
/home/sage/start-sage-os.sh: line 89: exec: qemu-system-aarch64: not found
```

**Root cause:** Alpine Linux Dockerfile was missing `qemu-system-aarch64` and `qemu-system-riscv64` packages.

### **✅ Changes Made:**

#### **1. Enhanced Alpine Linux QEMU Support:**
- ✅ **Added `qemu-system-aarch64`** - Enables ARM64 architecture support
- ✅ **Added `qemu-system-riscv64`** - Enables RISC-V 64-bit architecture support
- ✅ **Complete architecture coverage** - All SAGE OS architectures now supported

#### **2. Updated Package List:**
```dockerfile
# Before (missing architectures):
qemu-system-i386
qemu-system-arm  
qemu-system-x86_64

# After (complete support):
qemu-system-i386
qemu-system-arm
qemu-system-aarch64     # ← NEW
qemu-system-x86_64
qemu-system-riscv64     # ← NEW
```

### **🧪 Testing Results:**

#### **✅ Before Fix:**
- ❌ **aarch64**: `qemu-system-aarch64: not found`
- ❌ **riscv64**: `qemu-system-riscv64: not found`
- ✅ **i386**: Working
- ✅ **x86_64**: Working

#### **✅ After Fix:**
- ✅ **aarch64**: Full support with `qemu-system-aarch64`
- ✅ **riscv64**: Full support with `qemu-system-riscv64`
- ✅ **i386**: Continued support
- ✅ **x86_64**: Continued support

### **🎯 Impact:**

- **🚀 Enables aarch64 deployment** in Alpine Docker containers
- **🔧 Fixes critical deployment failures** for ARM64 systems
- **📦 Completes architecture support** for all SAGE OS targets
- **🐧 Maintains Alpine Linux compatibility** for lightweight deployments

### **📋 Verification Commands:**

```bash
# Test aarch64 deployment (now working):
./deploy-sage-os.sh deploy -d text -a aarch64

# Test riscv64 deployment (now working):
./deploy-sage-os.sh deploy -d text -a riscv64

# Verify QEMU availability in container:
docker run sage-os:latest which qemu-system-aarch64
docker run sage-os:latest which qemu-system-riscv64
```

### **🔗 Related Issues:**
- Resolves Docker deployment failures on aarch64 architecture
- Fixes Alpine Linux QEMU package incompleteness
- Enables full multi-architecture SAGE OS testing in containers

---

**Ready for merge** - Critical fix for Docker deployment ✅

**Author:** Ashish Vasant Yesale <ashishyesale007@gmail.com>

@mullaasad can click here to [continue refining the PR](https://app.all-hands.dev/17f6b8c53b4c44cfb6303022bbbccfb6)

## Summary by Sourcery

Add missing QEMU packages to the Alpine-based Docker deployment to enable ARM64 and RISC-V 64-bit support.

Bug Fixes:
- Fix missing qemu-system-aarch64 and qemu-system-riscv64 installations in the Alpine Docker image to resolve deployment errors

Build:
- Update Alpine Dockerfile to include additional QEMU architecture packages for full multi-arch coverage